### PR TITLE
feat(error-boundary): enviar reportes de error por email y mejorar UI

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,43 +1,216 @@
 import React from "react";
+import emailjs from "@emailjs/browser";
 
 type Props = {
   children: React.ReactNode;
 };
 
-type State = {
-  hasError: boolean;
+type ErrorReport = {
+  id: string;
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  url: string;
+  userAgent: string;
+  createdAt: string;
 };
 
+type State = {
+  hasError: boolean;
+  copied: boolean;
+  report: ErrorReport | null;
+  emailSent: boolean;
+};
+
+const ERROR_REPORT_EMAIL = "virtual.hache@gmail.com";
+const EMAILJS_SERVICE_ID =
+  import.meta.env.VITE_EMAILJS_SERVICE_ID || "service_ql4q72a";
+const EMAILJS_TEMPLATE_ID =
+  import.meta.env.VITE_EMAILJS_ERROR_TEMPLATE_ID ||
+  import.meta.env.VITE_EMAILJS_TEMPLATE_ID ||
+  "template_yt57d62";
+const EMAILJS_PUBLIC_KEY =
+  import.meta.env.VITE_EMAILJS_PUBLIC_KEY || "KtgXJK3IzzROv0Uhs";
+
 export class ErrorBoundary extends React.Component<Props, State> {
-  state: State = { hasError: false };
+  state: State = {
+    hasError: false,
+    copied: false,
+    report: null,
+    emailSent: false,
+  };
 
   static getDerivedStateFromError(): State {
-    return { hasError: true };
+    return { hasError: true, copied: false, report: null, emailSent: false };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("Error no controlado en la app", error, errorInfo);
+    const report = this.createErrorReport(error, errorInfo);
+
+    this.setState({ report });
+    this.saveErrorReport(report);
+    this.sendErrorReport(report);
+    console.error("Error no controlado en la app", report, error, errorInfo);
   }
+
+  createErrorReport(error: Error, errorInfo: React.ErrorInfo): ErrorReport {
+    return {
+      id: this.createErrorId(),
+      message: error.message || "Error sin mensaje",
+      stack: error.stack,
+      componentStack: errorInfo.componentStack || undefined,
+      url: window.location.href,
+      userAgent: window.navigator.userAgent,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  createErrorId() {
+    if (window.crypto?.randomUUID) {
+      return window.crypto.randomUUID().slice(0, 8).toUpperCase();
+    }
+
+    return Math.random().toString(36).slice(2, 10).toUpperCase();
+  }
+
+  saveErrorReport(report: ErrorReport) {
+    try {
+      window.localStorage.setItem("lastAppError", JSON.stringify(report));
+    } catch (error) {
+      console.warn("No se pudo guardar el reporte de error.", error);
+    }
+  }
+
+  hasReportAlreadyBeenSent(report: ErrorReport) {
+    try {
+      return window.sessionStorage.getItem(`sentAppError:${report.id}`) === "1";
+    } catch {
+      return false;
+    }
+  }
+
+  markReportAsSent(report: ErrorReport) {
+    try {
+      window.sessionStorage.setItem(`sentAppError:${report.id}`, "1");
+    } catch {
+      return;
+    }
+  }
+
+  sendErrorReport(report: ErrorReport) {
+    if (this.hasReportAlreadyBeenSent(report)) {
+      return;
+    }
+
+    const templateParams = {
+      to_email: ERROR_REPORT_EMAIL,
+      to_name: "WeTECH",
+      from_name: "Web WeTECH",
+      from_email: ERROR_REPORT_EMAIL,
+      subject: `Error web WeTECH ${report.id}`,
+      name: "ErrorBoundary",
+      phone: "No aplica",
+      zone: report.url,
+      message: this.getReportTextFromReport(report),
+      error_id: report.id,
+      error_message: report.message,
+      error_url: report.url,
+      error_date: report.createdAt,
+      user_agent: report.userAgent,
+      stack: report.stack || "Sin stack",
+      component_stack: report.componentStack || "Sin component stack",
+    };
+
+    emailjs
+      .send(
+        EMAILJS_SERVICE_ID,
+        EMAILJS_TEMPLATE_ID,
+        templateParams,
+        EMAILJS_PUBLIC_KEY
+      )
+      .then(() => {
+        this.markReportAsSent(report);
+        this.setState({ emailSent: true });
+      })
+      .catch((error) => {
+        console.error("No se pudo enviar el reporte de error por email.", error);
+      });
+  }
+
+  getReportTextFromReport(report: ErrorReport) {
+    return JSON.stringify(report, null, 2);
+  }
+
+  getReportText() {
+    if (!this.state.report) {
+      return "Reporte no disponible";
+    }
+
+    return this.getReportTextFromReport(this.state.report);
+  }
+
+  copyReport = async () => {
+    try {
+      await window.navigator.clipboard.writeText(this.getReportText());
+      this.setState({ copied: true });
+    } catch (error) {
+      console.warn("No se pudo copiar el reporte de error.", error);
+    }
+  };
 
   render() {
     if (this.state.hasError) {
+      const report = this.state.report;
+
       return (
         <div className="min-h-screen bg-gray-100 px-4 py-16">
           <div className="mx-auto max-w-lg rounded-lg bg-white p-6 text-center shadow-md">
             <h1 className="text-xl font-semibold text-gray-900">
-              No pudimos cargar esta sección
+              No pudimos cargar esta seccion
             </h1>
             <p className="mt-3 text-sm leading-6 text-gray-600">
-              Actualizá la página para volver a intentarlo. Si el problema
-              continúa, escribinos y te ayudamos con tu compra.
+              Actualiza la pagina para volver a intentarlo. Si el problema
+              continua, escribinos y te ayudamos con tu compra.
             </p>
-            <button
-              type="button"
-              onClick={() => window.location.reload()}
-              className="mt-6 rounded-lg bg-yellow-400 px-5 py-3 text-sm font-semibold text-gray-900 transition hover:bg-yellow-500"
-            >
-              Recargar página
-            </button>
+            {report && (
+              <div className="mt-5 rounded-lg border border-gray-200 bg-gray-50 p-4 text-left">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Codigo de error
+                </p>
+                <p className="mt-1 font-mono text-sm font-semibold text-gray-900">
+                  {report.id}
+                </p>
+                <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Detalle tecnico
+                </p>
+                <p className="mt-1 break-words text-sm text-gray-700">
+                  {report.message}
+                </p>
+                <p className="mt-3 text-xs text-gray-500">
+                  {this.state.emailSent
+                    ? "El reporte fue enviado automaticamente."
+                    : "Intentando enviar el reporte automaticamente."}
+                </p>
+              </div>
+            )}
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="rounded-lg bg-yellow-400 px-5 py-3 text-sm font-semibold text-gray-900 transition hover:bg-yellow-500"
+              >
+                Recargar pagina
+              </button>
+              {report && (
+                <button
+                  type="button"
+                  onClick={this.copyReport}
+                  className="rounded-lg border border-gray-300 px-5 py-3 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+                >
+                  {this.state.copied ? "Detalle copiado" : "Copiar detalle"}
+                </button>
+              )}
+            </div>
           </div>
         </div>
       );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -309,7 +309,7 @@ export function HomePage() {
       <ContactInfo />
 
       {/* Sección En Desarrollo */}
-      <section className="bg-gradient-to-r from-yellow-50 to-yellow-100 my-10 py-6 sm:py-8  lg:my-16 rounded-xl shadow-lg border-l-4 border-yellow-500">
+      {/* <section className="bg-gradient-to-r from-yellow-50 to-yellow-100 my-10 py-6 sm:py-8  lg:my-16 rounded-xl shadow-lg border-l-4 border-yellow-500">
         <div className="max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col sm:flex-row items-center justify-center mb-4 sm:mb-6">
             <div className="bg-yellow-200 p-2 sm:p-3 rounded-full mb-3 sm:mb-0 sm:mr-3">
@@ -386,7 +386,7 @@ export function HomePage() {
             Gracias por tu paciencia y por ayudarnos a crecer 🚀
           </p>
         </div>
-      </section>
+      </section> */}
     </div>
   );
 }

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -142,14 +142,14 @@ export function ProductsPage() {
   const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  const openWhatsApp = () => {
+  /* const openWhatsApp = () => {
     const phoneNumber = "5492615987988";
     const message = "¡Hola! Estoy interesado en realizar una compra. ¿Podrían ayudarme?";
     const whatsappUrl = `https://wa.me/${phoneNumber}?text=${encodeURIComponent(
       message
     )}`;
     window.open(whatsappUrl, "_blank");
-  };
+  }; */
 
   
 


### PR DESCRIPTION
- Integrar emailjs para enviar reportes de error a virtual.hache@gmail.com
- Generar ID único por error, evitar envíos duplicados con sessionStorage
- Guardar último error en localStorage para debugging
- Mostrar código de error, mensaje y estado del envío en UI
- Agregar botón para copiar detalle técnico al portapapeles
- Comentar función openWhatsApp no utilizada en ProductsPage