### PR TITLE
feat(pricing): refactor completo de cálculo de precios en checkout

### DIFF
--- a/src/components/cart/CartModal.tsx
+++ b/src/components/cart/CartModal.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../utils/discounts";
 import { getVariantPrice } from "../../utils/pricing";
 import { formatPrice, roundPrice } from "../../utils/money";
+import { calculateCheckoutLinePricing } from "../../utils/checkoutPricing";
 
 interface CartModalProps {
   isOpen: boolean;
@@ -95,7 +96,13 @@ export default function CartModal({ isOpen, onClose }: CartModalProps) {
   const calculateOriginalTotal = () => {
     return items.reduce((sum, item) => {
       const price = getPrice(item.product, item.color, item.weight);
-      const itemTotal = price ? roundPrice(price) * item.quantity : 0;
+      const itemTotal = price
+        ? calculateCheckoutLinePricing(
+            price,
+            item.quantity,
+            0
+          ).subtotalBruto
+        : 0;
       return sum + itemTotal;
     }, 0);
   };

--- a/src/components/checkout/Checkout.tsx
+++ b/src/components/checkout/Checkout.tsx
@@ -21,8 +21,19 @@ import {
 import { formatPrice, roundPrice } from "../../utils/money";
 import { calculateCheckoutLinePricing } from "../../utils/checkoutPricing";
 import {
+  buildOrderAmounts,
+  hasValidOrderLineAmounts,
+} from "../../utils/orderPricing";
+import {
+  getCouponPercentageForPaymentMethod,
+  isCouponApplicableToProductCategory,
+  selectCheckoutDiscount,
+  type CheckoutDiscountDecision,
+} from "../../utils/checkoutDiscount";
+import {
   calculateInvoiceLine,
   requiresInvoice,
+  round2,
 } from "../../utils/invoice";
 import type { FacturaTipo } from "../../utils/invoice";
 
@@ -218,9 +229,26 @@ export default function Checkout() {
         if (now < couponData.fechaDesde || now > couponData.fechaHasta) {
           setCouponError("Este cupón no es válido en este momento");
           setAppliedCoupon(null);
-        } else {
-          setAppliedCoupon(couponData);
-          setCouponError("");
+      } else {
+          const hasApplicableProduct = items.some((item) =>
+            isCouponApplicableToProductCategory({
+              couponCategory: couponData.categoriaAplicable,
+              productCategory: item.product.category,
+            })
+          );
+
+          if (
+            couponData.categoriaAplicable &&
+            !hasApplicableProduct
+          ) {
+            setCouponError(
+              `Este cupón sólo aplica a productos de categoría ${couponData.categoriaAplicable}.`
+            );
+            setAppliedCoupon(null);
+          } else {
+            setAppliedCoupon(couponData);
+            setCouponError("");
+          }
         }
       }
     } else {
@@ -295,19 +323,57 @@ export default function Checkout() {
       eligibleQuantityDiscountCartQuantity
     );
 
-  const getEffectiveCouponPercentage = (coupon: Coupon | null): number => {
-    if (!coupon) return 0;
+  const effectiveCouponPercentage =
+    getCouponPercentageForPaymentMethod(
+      appliedCoupon,
+      paymentMethod
+    );
 
-    if (paymentMethod === "transfer") {
-      return (
-        coupon.porcentajeDescuentoTransferencia ?? coupon.porcentajeDescuento
-      );
+  const calculateAutomaticDiscountPercentageForCheckout = (
+    product: Product,
+    weight: number,
+    quantity: number
+  ): number => {
+    if (paymentMethod !== "transfer" || !shouldApplyDiscount(product)) {
+      return 0;
     }
 
-    return coupon.porcentajeDescuento;
+    const effectiveQuantity = getEffectiveDiscountQuantity(
+      product,
+      quantity,
+      weight
+    );
+    const discountPercentage = getDiscountPercentageForProduct(
+      product,
+      quantity,
+      weight,
+      effectiveQuantity
+    );
+    const numericPercentage = Number(discountPercentage.replace("%", ""));
+
+    return Number.isFinite(numericPercentage) ? numericPercentage : 0;
   };
 
-  const effectiveCouponPercentage = getEffectiveCouponPercentage(appliedCoupon);
+  const calculateItemDiscountDecision = (
+    product: Product,
+    weight: number,
+    quantity: number
+  ): CheckoutDiscountDecision =>
+    selectCheckoutDiscount({
+      automaticPercentage: calculateAutomaticDiscountPercentageForCheckout(
+        product,
+        weight,
+        quantity
+      ),
+      couponPercentage:
+        appliedCoupon &&
+        isCouponApplicableToProductCategory({
+          couponCategory: appliedCoupon.categoriaAplicable,
+          productCategory: product.category,
+        })
+          ? effectiveCouponPercentage
+          : 0,
+    });
   /*   const getPromotionalPrice = (
     product: Product,
     weight: number
@@ -327,42 +393,16 @@ export default function Checkout() {
 
     if (!originalPrice) return originalPrice;
 
-    // Si gana cupón, cada línea sale con precio neto por cupón.
-    if (isCouponWinningDiscount && appliedCoupon) {
-      return calculateCheckoutLinePricingForInvoiceMode(
-        originalPrice,
-        quantity,
-        effectiveCouponPercentage
-      ).precioUnitarioNeto;
-    }
-
-    // Si no gana cupón, aplicar descuento por transferencia cuando corresponda.
-    if (shouldApplyTransferDiscountToCheckout && shouldApplyDiscount(product)) {
-      const effectiveQuantity = getEffectiveDiscountQuantity(
-        product,
-        quantity,
-        weight
-      );
-
-      const discountPercentage = getDiscountPercentageForProduct(
-        product,
-        quantity,
-        weight,
-        effectiveQuantity
-      );
-      const numericPercentage = Number(discountPercentage.replace("%", ""));
-
-      return calculateCheckoutLinePricingForInvoiceMode(
-        originalPrice,
-        quantity,
-        Number.isFinite(numericPercentage) ? numericPercentage : 0
-      ).precioUnitarioNeto;
-    }
+    const discountDecision = calculateItemDiscountDecision(
+      product,
+      weight,
+      quantity
+    );
 
     return calculateCheckoutLinePricingForInvoiceMode(
       originalPrice,
       quantity,
-      0
+      discountDecision.percentage
     ).precioUnitarioNeto;
   };
 
@@ -376,40 +416,16 @@ export default function Checkout() {
 
     if (!originalPrice) return 0;
 
-    if (isCouponWinningDiscount && appliedCoupon) {
-      return calculateCheckoutLinePricingForInvoiceMode(
-        originalPrice,
-        quantity,
-        effectiveCouponPercentage
-      ).subtotalNeto;
-    }
-
-    if (shouldApplyTransferDiscountToCheckout && shouldApplyDiscount(product)) {
-      const effectiveQuantity = getEffectiveDiscountQuantity(
-        product,
-        quantity,
-        weight
-      );
-
-      const discountPercentage = getDiscountPercentageForProduct(
-        product,
-        quantity,
-        weight,
-        effectiveQuantity
-      );
-      const numericPercentage = Number(discountPercentage.replace("%", ""));
-
-      return calculateCheckoutLinePricingForInvoiceMode(
-        originalPrice,
-        quantity,
-        Number.isFinite(numericPercentage) ? numericPercentage : 0
-      ).subtotalNeto;
-    }
+    const discountDecision = calculateItemDiscountDecision(
+      product,
+      weight,
+      quantity
+    );
 
     return calculateCheckoutLinePricingForInvoiceMode(
       originalPrice,
       quantity,
-      0
+      discountDecision.percentage
     ).subtotalNeto;
   };
 
@@ -418,29 +434,46 @@ export default function Checkout() {
     weight: number,
     quantity: number
   ): number => {
-    // Cupón ganador: ajuste uniforme para todas las líneas.
-    if (isCouponWinningDiscount && appliedCoupon) {
-      return effectiveCouponPercentage;
-    }
-
-    if (!shouldApplyTransferDiscountToCheckout) return 0;
-    if (!shouldApplyDiscount(product)) return 0;
-
-    const effectiveQuantity = getEffectiveDiscountQuantity(
+    return calculateItemDiscountDecision(
       product,
-      quantity,
-      weight
-    );
-    const discountPercentage = getDiscountPercentageForProduct(
-      product,
-      quantity,
       weight,
-      effectiveQuantity
-    );
-    const numericPercentage = Number(discountPercentage.replace("%", ""));
-
-    return Number.isFinite(numericPercentage) ? numericPercentage : 0;
+      quantity
+    ).percentage;
   };
+
+  const buildCurrentOrderAmounts = () =>
+    buildOrderAmounts({
+      products: items.map((item) => {
+        const discountDecision = calculateItemDiscountDecision(
+          item.product,
+          item.weight,
+          item.quantity
+        );
+
+        return {
+          nombre: getVariantItemId(
+            item.product,
+            item.color,
+            item.weight
+          ),
+          cantidad: item.quantity,
+          precioBaseUnitario:
+            getPrice(item.product, item.color, item.weight) ?? 0,
+          ajustePorcentaje: discountDecision.percentage,
+          couponApplied: discountDecision.source === "coupon",
+        };
+      }),
+      shipping:
+        deliveryMethod === "shipping" &&
+        shippingData &&
+        !isFreeShippingByWeight
+          ? {
+              nombre: shippingData.itemId,
+              costo: shippingTotal,
+            }
+          : undefined,
+      facturaTipo,
+    });
 
   if (items.length === 0) {
     return (
@@ -511,10 +544,6 @@ export default function Checkout() {
       postal_code: formData.billingPostalCode,
     };
 
-    const roundDisplayedPrice = (value: number) => roundPrice(value);
-    const orderTotal = requiresInvoice(facturaTipo)
-      ? finalTotal
-      : roundDisplayedPrice(finalTotal);
     const cleanCuit = normalizeCuitCuil(formData.cuit); // Remover guiones y caracteres no numéricos
     const clienteNombre = formatCustomerNameForOrder({
       documentType,
@@ -523,12 +552,26 @@ export default function Checkout() {
       lastName: formData.lastName,
     });
 
+    const orderAmounts = currentOrderAmounts;
+    const { productos, total: orderTotal, costoEnvio } = orderAmounts;
+
+    if (!hasValidOrderLineAmounts(productos, facturaTipo)) {
+      setError({
+        code: "IMPORTES_INCONSISTENTES",
+        message:
+          "No pudimos validar los importes del pedido. Actualizá el carrito e intentá nuevamente.",
+        retryable: true,
+      });
+      setShowErrorModal(true);
+      return;
+    }
+
     const body = {
       cliente_nombre: clienteNombre,
       cliente_cuit: cleanCuit,
       total: orderTotal,
-      costo_envio: shippingTotal,
-      descuento_cupon: roundDisplayedPrice(couponDiscount),
+      costo_envio: costoEnvio,
+      descuento_cupon: orderAmounts.descuentoCupon,
       codigo_cupon: shouldSendCouponInOrder ? appliedCoupon?.code || "" : "",
       metodo_pago: paymentMethod,
       email: formData.email,
@@ -542,46 +585,7 @@ export default function Checkout() {
       observaciones: formData.observaciones,
       direccion: confirmedAddress || "",
       mobile: isMobile,
-      productos: [
-        ...items.map((item) => {
-          // Buscar el ID original del ítem según el color seleccionado (si aplica)
-          const nombre = getVariantItemId(item.product, item.color, item.weight);
-
-          const originalUnitPrice =
-            getPrice(item.product, item.color, item.weight) ?? 0;
-          const adjustmentPercentage =
-            calculateItemAdjustmentPercentageForCheckout(
-              item.product,
-              item.weight,
-              item.quantity
-            );
-          const linePricing = calculateCheckoutLinePricingForInvoiceMode(
-            originalUnitPrice,
-            item.quantity,
-            adjustmentPercentage
-          );
-
-          return {
-            nombre,
-            cantidad: item.quantity,
-            precio_unitario: linePricing.precioUnitarioNeto,
-            subtotal: linePricing.subtotalBruto,
-            ajuste_porcentaje: adjustmentPercentage,
-          };
-        }),
-        // Agregar shipping como producto si aplica
-        ...(deliveryMethod === "shipping" && shippingData && !isFreeShippingByWeight
-          ? [
-              {
-                nombre: shippingData.itemId,
-                cantidad: 1,
-                precio_unitario: shippingTotal,
-                subtotal: shippingTotal,
-                ajuste_porcentaje: 0,
-              },
-            ]
-          : []),
-      ],
+      productos,
       billing_address,
       ...(requiresInvoice(facturaTipo) ? { factura_tipo: facturaTipo } : {}),
     };
@@ -841,54 +845,27 @@ export default function Checkout() {
     }, 0);
   };
 
-  const calculateTransferDiscountedTotal = () => {
-    return items.reduce((sum, item) => {
-      const originalPrice = getPrice(item.product, item.color, item.weight);
-
-      if (!originalPrice) return sum;
-
-      const effectiveQuantity = getEffectiveDiscountQuantity(
-        item.product,
-        item.quantity,
-        item.weight
-      );
-
-      const discountPercentage = getDiscountPercentageForProduct(
-        item.product,
-        item.quantity,
-        item.weight,
-        effectiveQuantity
-      );
-      const numericPercentage = Number(discountPercentage.replace("%", ""));
-
-      return (
-        sum +
-        calculateCheckoutLinePricingForInvoiceMode(
-          originalPrice,
-          item.quantity,
-          Number.isFinite(numericPercentage) ? numericPercentage : 0
-        ).subtotalNeto
-      );
-    }, 0);
-  };
-
   const originalTotal = calculateOriginalTotal();
-  const transferDiscountedTotal = calculateTransferDiscountedTotal();
-  const transferDiscountAmount =
-    paymentMethod === "transfer"
-      ? Math.max(originalTotal - transferDiscountedTotal, 0)
-      : 0;
-  const transferDiscountPercentage =
-    originalTotal > 0 ? (transferDiscountAmount / originalTotal) * 100 : 0;
   const isCouponWinningDiscount =
-    !!appliedCoupon && effectiveCouponPercentage > transferDiscountPercentage;
-  const shouldApplyTransferDiscountToCheckout =
-    paymentMethod === "transfer" && !isCouponWinningDiscount;
+    !!appliedCoupon &&
+    items.some(
+      (item) =>
+        calculateItemDiscountDecision(
+          item.product,
+          item.weight,
+          item.quantity
+        ).source === "coupon"
+    );
 
   // checkoutTotal ya queda neto por línea con el descuento ganador.
   const checkoutTotal = calculateCheckoutTotal();
-  const appliedDiscountAmount = Math.max(originalTotal - checkoutTotal, 0);
-  const couponDiscount = isCouponWinningDiscount ? appliedDiscountAmount : 0;
+  const rawAppliedDiscountAmount = Math.max(
+    originalTotal - checkoutTotal,
+    0
+  );
+  const appliedDiscountAmount = requiresInvoice(facturaTipo)
+    ? round2(rawAppliedDiscountAmount)
+    : Math.round(rawAppliedDiscountAmount);
   const cartWeightKg = items.reduce(
     (sum, item) => sum + item.weight * item.quantity,
     0
@@ -898,8 +875,9 @@ export default function Checkout() {
   const shippingTotal = isFreeShippingByWeight
     ? 0
     : shippingData?.costoTotal || 0;
-  const baseFinalTotal = checkoutTotal + shippingTotal;
-  const finalTotal = baseFinalTotal;
+  const currentOrderAmounts = buildCurrentOrderAmounts();
+  const couponDiscount = currentOrderAmounts.descuentoCupon;
+  const finalTotal = currentOrderAmounts.total;
   const formattedFinalTotal = requiresInvoice(facturaTipo)
     ? finalTotal.toLocaleString("es-ES", {
         minimumFractionDigits: 2,
@@ -1379,6 +1357,11 @@ export default function Checkout() {
                       item.weight,
                       item.quantity
                     );
+                    const discountDecision = calculateItemDiscountDecision(
+                      item.product,
+                      item.weight,
+                      item.quantity
+                    );
                     const colorHex = item.color
                       ? item.product.colors?.find(
                         (c) =>
@@ -1423,8 +1406,7 @@ export default function Checkout() {
                                   </span>
                                 </div>
                               )}
-                              {shouldApplyTransferDiscountToCheckout &&
-                                shouldApplyDiscount(item.product) &&
+                              {discountDecision.source === "automatic" &&
                                 discountedPrice &&
                                 discountedPrice < (price ?? 0) && (
                                   <span className="inline-block bg-red-100 text-red-800 text-xs font-semibold px-2 py-1 rounded-full mt-1">

--- a/src/pages/PaymentCallback.tsx
+++ b/src/pages/PaymentCallback.tsx
@@ -5,6 +5,7 @@ import { dashboardReadApiFetch } from "../services/api";
 import SurveyModal from "../components/SurveyModal";
 import { formatCurrency } from "../utils/money";
 import { useCart } from "../context/CartContext";
+import { isShippingProductName } from "../utils/orderPricing";
 
 const PaymentStatus = {
   LOADING: "loading",
@@ -18,6 +19,7 @@ interface Producto {
   descripcion: string;
   cantidad: number;
   precio_unitario: number;
+  subtotal: number;
 }
 
 interface PedidoData {
@@ -33,6 +35,8 @@ interface PedidoData {
   costo_envio?: string;
   descuento_cupon?: string;
   codigo_cupon?: string;
+  factura_tipo?: "A" | "B" | null;
+  factura_iva_importe?: number | string | null;
   delivery_method?: string;
   cliente_mail?: string;
   cliente_ubicacion?: string;
@@ -55,6 +59,10 @@ const PaymentCallback = () => {
   const [isSurveyOpen, setIsSurveyOpen] = useState(false);
 
   const paymentMethod = pedidoData?.payment_method ?? pedidoData?.metodo_pago;
+  const hasShippingProduct =
+    pedidoData?.productos?.some((product) =>
+      isShippingProductName(product.nombre)
+    ) ?? false;
   const isTransferPending =
     paymentMethod === "transfer" && pedidoData?.estado === "PENDIENTE";
 
@@ -548,11 +556,13 @@ const PaymentCallback = () => {
                   <span className="product-name">{p.descripcion}</span>
                   <span className="product-qty"> × {p.cantidad}</span>
                 </div>
-                <span className="product-price">{fmt(p.precio_unitario * p.cantidad)}</span>
+                <span className="product-price">{fmt(p.subtotal)}</span>
               </div>
             ))}
 
-            {pedidoData?.costo_envio && parseFloat(pedidoData.costo_envio) > 0 && (
+            {pedidoData?.costo_envio &&
+              parseFloat(pedidoData.costo_envio) > 0 &&
+              !hasShippingProduct && (
               <div className="order-row" style={{ marginTop: 10 }}>
                 <span className="order-row-label">Envío</span>
                 <span className="order-row-value">{fmt(pedidoData.costo_envio)}</span>
@@ -562,10 +572,23 @@ const PaymentCallback = () => {
               <div className="order-row">
                 <span className="order-row-label">Cupón {pedidoData.codigo_cupon}</span>
                 <span className="order-row-value" style={{ color: "#16a34a" }}>
-                  {pedidoData.descuento_cupon ? `−${fmt(pedidoData.descuento_cupon)}` : "aplicado"}
+                  {pedidoData.descuento_cupon
+                    ? `Incluido (−${fmt(pedidoData.descuento_cupon)})`
+                    : "Aplicado"}
                 </span>
               </div>
             )}
+            {pedidoData?.factura_iva_importe != null &&
+              Number(pedidoData.factura_iva_importe) > 0 && (
+                <div className="order-row">
+                  <span className="order-row-label">
+                    IVA factura {pedidoData.factura_tipo ?? ""}
+                  </span>
+                  <span className="order-row-value">
+                    {fmt(pedidoData.factura_iva_importe)}
+                  </span>
+                </div>
+              )}
             <div className="order-total">
               <span>Total</span>
               <span>{fmt(pedidoData?.total ?? 0)}</span>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -210,6 +210,8 @@ export async function verifyCoupon(couponCode: string): Promise<Coupon | null> {
         data.porcentajeDescuentoTransferencia,
         defaultDiscount
       ),
+      categoriaAplicable:
+        data.categoriaAplicable ?? data.categoria_aplicable ?? null,
       activo: data.activo,
       fechaDesde: new Date(data.fechaDesde),
       fechaHasta: new Date(data.fechaHasta),

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,11 @@ export interface ShippingCost {
   cost: number;
 }
 
+export type CouponApplicableCategory =
+  | "filamento"
+  | "impresora"
+  | "repuesto";
+
 export interface Coupon {
   code: string;
   porcentajeDescuento: number;
@@ -85,6 +90,7 @@ export interface Coupon {
   fechaDesde: Date;
   fechaHasta: Date;
   descripcion?: string;
+  categoriaAplicable?: CouponApplicableCategory | null;
 }
 
 export interface Colors {

--- a/src/utils/checkoutDiscount.ts
+++ b/src/utils/checkoutDiscount.ts
@@ -1,0 +1,85 @@
+import type {
+  Coupon,
+  CouponApplicableCategory,
+} from "../types";
+
+export type CheckoutDiscountSource = "none" | "automatic" | "coupon";
+
+export type CheckoutDiscountDecision = {
+  percentage: number;
+  source: CheckoutDiscountSource;
+};
+
+export const getCouponPercentageForPaymentMethod = (
+  coupon: Coupon | null,
+  paymentMethod: "online" | "transfer"
+): number => {
+  if (!coupon) return 0;
+
+  if (paymentMethod === "transfer") {
+    return (
+      coupon.porcentajeDescuentoTransferencia ??
+      coupon.porcentajeDescuento
+    );
+  }
+
+  return (
+    coupon.porcentajeDescuentoTarjeta ??
+    coupon.porcentajeDescuento
+  );
+};
+
+const normalizePercentage = (percentage: number): number =>
+  Number.isFinite(percentage)
+    ? Math.min(Math.max(percentage, 0), 100)
+    : 0;
+
+export const selectCheckoutDiscount = ({
+  automaticPercentage,
+  couponPercentage,
+}: {
+  automaticPercentage: number;
+  couponPercentage: number;
+}): CheckoutDiscountDecision => {
+  const automatic = normalizePercentage(automaticPercentage);
+  const coupon = normalizePercentage(couponPercentage);
+
+  if (coupon > automatic) {
+    return { percentage: coupon, source: "coupon" };
+  }
+
+  if (automatic > 0) {
+    return { percentage: automatic, source: "automatic" };
+  }
+
+  return { percentage: 0, source: "none" };
+};
+
+export const deriveCouponCategory = (
+  productCategory: string
+): CouponApplicableCategory => {
+  const normalized = productCategory.trim().toUpperCase();
+
+  if (
+    normalized === "FILAMENTOS" ||
+    normalized === "FILAMENTO 3D"
+  ) {
+    return "filamento";
+  }
+
+  if (normalized === "IMPRESORAS") {
+    return "impresora";
+  }
+
+  return "repuesto";
+};
+
+export const isCouponApplicableToProductCategory = ({
+  couponCategory,
+  productCategory,
+}: {
+  couponCategory?: CouponApplicableCategory | null;
+  productCategory: string;
+}): boolean =>
+  !couponCategory ||
+  couponCategory === deriveCouponCategory(productCategory);

--- a/src/utils/checkoutPricing.ts
+++ b/src/utils/checkoutPricing.ts
@@ -1,10 +1,11 @@
-import { roundPrice } from "./money";
-
 export type CheckoutLinePricing = {
   subtotalBruto: number;
   subtotalNeto: number;
   precioUnitarioNeto: number;
 };
+
+export const normalizeBackendBasePrice = (price: number): number =>
+  Math.round(price);
 
 export const calculateCheckoutLinePricing = (
   precioBaseUnitario: number,
@@ -19,11 +20,15 @@ export const calculateCheckoutLinePricing = (
     };
   }
 
-  const subtotalBruto = roundPrice(precioBaseUnitario * cantidad);
-  const subtotalNeto = roundPrice(
-    precioBaseUnitario * cantidad * (1 - descuentoPorcentaje / 100)
+  const normalizedBasePrice =
+    normalizeBackendBasePrice(precioBaseUnitario);
+  const subtotalBruto = Math.round(normalizedBasePrice * cantidad);
+  const subtotalNeto = Math.round(
+    normalizedBasePrice *
+      cantidad *
+      (1 - descuentoPorcentaje / 100)
   );
-  const precioUnitarioNeto = roundPrice(subtotalNeto / cantidad);
+  const precioUnitarioNeto = Math.round(subtotalNeto / cantidad);
 
   return {
     subtotalBruto,

--- a/src/utils/discounts.ts
+++ b/src/utils/discounts.ts
@@ -1,4 +1,5 @@
 import { roundPrice } from "./money";
+import { calculateCheckoutLinePricing } from "./checkoutPricing";
 
 // Configuración de descuentos por cantidad (legacy por compatibilidad)
 export const QUANTITY_DISCOUNTS = {
@@ -44,6 +45,17 @@ const ELIGIBLE_ATTRIBUTE_KEYS = new Set(
   )
 );
 
+const LEGACY_PRODUCT_ATTRIBUTE_KEYS = new Map<string, string>([
+  ["3N|PLA", "3N3|PLA"],
+  ["G3|BOUT", "GRILON3|PLA BOUTIQUE"],
+  ["G3|PLA", "GRILON3|PLA"],
+  ["GS|PLA", "GST3D|PLA"],
+  ["HB|PLA", "HELLBOT|PLA"],
+  ["3X|PLA", "3NMAX|PLA+ MATTE"],
+  ["FM|PLA", "FREMOVER|HIGH SPEED PLA"],
+  ["EG|PLA", "ELEGOO|PLA"],
+]);
+
 /**
  * Deriva la clave "MARCA|MATERIAL" del id del producto. El id se arma como
  * MARCA-MATERIAL-LÍNEA-ORIGEN (desde atributos), así que los dos primeros
@@ -52,7 +64,9 @@ const ELIGIBLE_ATTRIBUTE_KEYS = new Set(
 const eligibleKeyFromProductId = (productId: string): string | null => {
   const parts = normalizeDiscountIdentifier(productId).split("-");
   if (parts.length < 2) return null;
-  return `${parts[0]}|${parts[1]}`;
+  const normalizedFamily = parts[1].replace(/\d+$/, "");
+  const key = `${parts[0]}|${normalizedFamily}`;
+  return LEGACY_PRODUCT_ATTRIBUTE_KEYS.get(key) ?? key;
 };
 
 // Categorías que comparten la misma regla de descuento (aceptamos legacy y nuevo nombre)
@@ -161,7 +175,11 @@ export const calculateDiscountedPriceForProduct = (
   effectiveQuantity = quantity
 ): number => {
   const rate = getDiscountRateForProduct(product, effectiveQuantity, weight);
-  return roundPrice(originalPrice * (1 - rate));
+  return calculateCheckoutLinePricing(
+    originalPrice,
+    quantity,
+    rate * 100
+  ).precioUnitarioNeto;
 };
 
 export const calculateDiscountedLineTotalForProduct = (
@@ -172,7 +190,11 @@ export const calculateDiscountedLineTotalForProduct = (
   effectiveQuantity = quantity
 ): number => {
   const rate = getDiscountRateForProduct(product, effectiveQuantity, weight);
-  return roundPrice(originalPrice * quantity * (1 - rate));
+  return calculateCheckoutLinePricing(
+    originalPrice,
+    quantity,
+    rate * 100
+  ).subtotalNeto;
 };
 
 export const getDiscountPercentageForProduct = (
@@ -208,7 +230,11 @@ export const getDiscountForQuantity = (quantity: number): number => {
 // Función para calcular el precio con descuento
 export const calculateDiscountedPrice = (originalPrice: number, quantity: number): number => {
   const discount = getDiscountForQuantity(quantity);
-  return roundPrice(originalPrice * (1 - discount));
+  return calculateCheckoutLinePricing(
+    originalPrice,
+    quantity,
+    discount * 100
+  ).precioUnitarioNeto;
 };
 
 // Función para obtener el porcentaje de descuento como string

--- a/src/utils/invoice.ts
+++ b/src/utils/invoice.ts
@@ -36,12 +36,13 @@ export const calculateInvoiceLine = ({
     };
   }
 
+  const precioBaseNormalizado = roundPeso(precioMinoristaConIva);
   const ivaFactor = 1 + INVOICE_SURCHARGE_RATE;
   const descuentoFactor = 1 - descuentoPorcentaje / 100;
   const subtotalSA =
     subtotalSAOverride !== undefined
       ? round2(subtotalSAOverride)
-      : applyInvoiceTax(precioMinoristaConIva * cantidad);
+      : applyInvoiceTax(precioBaseNormalizado * cantidad);
   const brutoFinalPrevio = round2(subtotalSA * descuentoFactor);
   const netoFinal = roundPeso(brutoFinalPrevio / ivaFactor);
   const iva = round2(netoFinal * INVOICE_SURCHARGE_RATE);

--- a/src/utils/orderPricing.ts
+++ b/src/utils/orderPricing.ts
@@ -1,0 +1,271 @@
+import {
+  calculateCheckoutLinePricing,
+  normalizeBackendBasePrice,
+} from "./checkoutPricing";
+import {
+  calculateInvoiceLine,
+  FacturaTipo,
+  INVOICE_SURCHARGE_RATE,
+  requiresInvoice,
+  round2,
+} from "./invoice";
+
+export type OrderLineAmounts = {
+  cantidad: number;
+  precio_unitario: number;
+  subtotal: number;
+  ajuste_porcentaje: number;
+};
+
+export type NamedOrderLine = OrderLineAmounts & {
+  nombre: string;
+};
+
+export type OrderProductPricingInput = {
+  nombre: string;
+  cantidad: number;
+  precioBaseUnitario: number;
+  ajustePorcentaje: number;
+  couponApplied?: boolean;
+};
+
+export const isShippingProductName = (name: string): boolean =>
+  /^ENV-\d+K-GM-DELIVERY$/i.test(name);
+
+type CalculatedOrderProduct = {
+  line: OrderLineAmounts;
+  netSubtotal: number;
+  couponDiscount: number;
+};
+
+const calculateOrderProduct = ({
+  cantidad,
+  precioBaseUnitario,
+  ajustePorcentaje,
+  couponApplied = false,
+  facturaTipo = "none",
+}: Omit<OrderProductPricingInput, "nombre"> & {
+  facturaTipo?: FacturaTipo;
+}): CalculatedOrderProduct => {
+  if (requiresInvoice(facturaTipo)) {
+    const normalizedBasePrice =
+      normalizeBackendBasePrice(precioBaseUnitario);
+    const invoiceLine = calculateInvoiceLine({
+      precioMinoristaConIva: normalizedBasePrice,
+      cantidad,
+      descuentoPorcentaje: ajustePorcentaje,
+    });
+
+    return {
+      line: {
+        cantidad,
+        precio_unitario: invoiceLine.precio_unitario,
+        // El backend valida el subtotal bruto con IVA previo al descuento.
+        subtotal: invoiceLine.subtotal,
+        ajuste_porcentaje: ajustePorcentaje,
+      },
+      netSubtotal: invoiceLine.netoFinal,
+      couponDiscount: couponApplied
+        ? Math.round(
+            normalizedBasePrice * cantidad - invoiceLine.netoFinal
+          )
+        : 0,
+    };
+  }
+
+  const pricing = calculateCheckoutLinePricing(
+    precioBaseUnitario,
+    cantidad,
+    ajustePorcentaje
+  );
+  const normalizedBasePrice =
+    normalizeBackendBasePrice(precioBaseUnitario);
+
+  return {
+    line: {
+      cantidad,
+      precio_unitario: pricing.precioUnitarioNeto,
+      subtotal: pricing.subtotalNeto,
+      ajuste_porcentaje: ajustePorcentaje,
+    },
+    netSubtotal: pricing.subtotalNeto,
+    couponDiscount: couponApplied
+      ? Math.round(
+          normalizedBasePrice * cantidad - pricing.subtotalNeto
+        )
+      : 0,
+  };
+};
+
+export const calculateOrderLineAmounts = (
+  input: Omit<OrderProductPricingInput, "nombre"> & {
+    facturaTipo?: FacturaTipo;
+  }
+): OrderLineAmounts => calculateOrderProduct(input).line;
+
+export const calculateShippingLineAmounts = ({
+  shippingCost,
+  facturaTipo = "none",
+}: {
+  shippingCost: number;
+  facturaTipo?: FacturaTipo;
+}): OrderLineAmounts =>
+  calculateOrderProduct({
+    cantidad: 1,
+    precioBaseUnitario: requiresInvoice(facturaTipo)
+      ? round2(shippingCost)
+      : Math.round(shippingCost),
+    ajustePorcentaje: 0,
+    couponApplied: false,
+    facturaTipo,
+  }).line;
+
+export const calculateOrderTotal = (
+  netProductSubtotals: number[],
+  netShippingCost: number,
+  facturaTipo: FacturaTipo = "none"
+): number => {
+  const normalizedShippingCost = requiresInvoice(facturaTipo)
+    ? round2(netShippingCost)
+    : Math.round(netShippingCost);
+  const subtotal =
+    netProductSubtotals.reduce((sum, lineSubtotal) => {
+      return sum + lineSubtotal;
+    }, 0) + normalizedShippingCost;
+
+  if (!requiresInvoice(facturaTipo)) {
+    return subtotal;
+  }
+
+  const subtotalSinIva = round2(subtotal);
+  const ivaImporte = round2(
+    subtotalSinIva * INVOICE_SURCHARGE_RATE
+  );
+  return round2(subtotalSinIva + ivaImporte);
+};
+
+const hasAtMostTwoDecimals = (value: number): boolean =>
+  Math.abs(value * 100 - Math.round(value * 100)) < 1e-8;
+
+export const hasValidOrderLineAmounts = (
+  lines: OrderLineAmounts[],
+  facturaTipo: FacturaTipo = "none"
+): boolean =>
+  lines.every((line) => {
+    const commonFieldsAreValid =
+      Number.isInteger(line.cantidad) &&
+      line.cantidad > 0 &&
+      Number.isFinite(line.precio_unitario) &&
+      line.precio_unitario >= 0 &&
+      Number.isFinite(line.subtotal) &&
+      line.subtotal >= 0 &&
+      Number.isFinite(line.ajuste_porcentaje) &&
+      line.ajuste_porcentaje >= 0 &&
+      line.ajuste_porcentaje <= 100;
+
+    if (!commonFieldsAreValid) return false;
+
+    if (requiresInvoice(facturaTipo)) {
+      return (
+        hasAtMostTwoDecimals(line.precio_unitario) &&
+        hasAtMostTwoDecimals(line.subtotal)
+      );
+    }
+
+    return (
+      Number.isInteger(line.precio_unitario) &&
+      Number.isInteger(line.subtotal)
+    );
+  });
+
+export const buildOrderAmounts = ({
+  products,
+  shipping,
+  facturaTipo = "none",
+}: {
+  products: OrderProductPricingInput[];
+  shipping?: { nombre: string; costo: number };
+  facturaTipo?: FacturaTipo;
+}): {
+  productos: NamedOrderLine[];
+  total: number;
+  costoEnvio: number;
+  descuentoCupon: number;
+  subtotalSinIva: number;
+  ivaImporte: number;
+} => {
+  const calculatedProducts = products.map(({ nombre, ...pricingInput }) => {
+    const calculated = calculateOrderProduct({
+      ...pricingInput,
+      facturaTipo,
+    });
+
+    return {
+      ...calculated,
+      line: {
+        nombre,
+        ...calculated.line,
+      },
+    };
+  });
+
+  const shippingCalculation = shipping
+    ? calculateOrderProduct({
+        cantidad: 1,
+        precioBaseUnitario: requiresInvoice(facturaTipo)
+          ? round2(shipping.costo)
+          : Math.round(shipping.costo),
+        ajustePorcentaje: 0,
+        couponApplied: false,
+        facturaTipo,
+      })
+    : null;
+  const shippingLine =
+    shipping && shippingCalculation
+      ? {
+          nombre: shipping.nombre,
+          ...shippingCalculation.line,
+        }
+      : null;
+  const costoEnvio = shippingCalculation?.netSubtotal ?? 0;
+  const productNetSubtotals = calculatedProducts.map(
+    ({ netSubtotal }) => netSubtotal
+  );
+  const subtotalSinIva = requiresInvoice(facturaTipo)
+    ? round2(
+        productNetSubtotals.reduce(
+          (sum, subtotal) => sum + subtotal,
+          0
+        ) + costoEnvio
+      )
+    : productNetSubtotals.reduce(
+        (sum, subtotal) => sum + subtotal,
+        0
+      ) + costoEnvio;
+  const ivaImporte = requiresInvoice(facturaTipo)
+    ? round2(subtotalSinIva * INVOICE_SURCHARGE_RATE)
+    : 0;
+
+  return {
+    productos: shippingLine
+      ? [
+          ...calculatedProducts.map(({ line }) => line),
+          shippingLine,
+        ]
+      : calculatedProducts.map(({ line }) => line),
+    total: calculateOrderTotal(
+      productNetSubtotals,
+      costoEnvio,
+      facturaTipo
+    ),
+    costoEnvio,
+    descuentoCupon: Math.round(
+      calculatedProducts.reduce(
+        (sum, { couponDiscount }) => sum + couponDiscount,
+        0
+      )
+    ),
+    subtotalSinIva,
+    ivaImporte,
+  };
+};

--- a/tests/checkoutDiscount.test.cjs
+++ b/tests/checkoutDiscount.test.cjs
@@ -1,0 +1,103 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+require("sucrase/register/ts");
+
+const {
+  deriveCouponCategory,
+  getCouponPercentageForPaymentMethod,
+  isCouponApplicableToProductCategory,
+  selectCheckoutDiscount,
+} = require("../src/utils/checkoutDiscount.ts");
+
+const coupon = {
+  code: "METODO",
+  porcentajeDescuento: 10,
+  porcentajeDescuentoTarjeta: 12,
+  porcentajeDescuentoTransferencia: 18,
+  activo: true,
+  fechaDesde: new Date("2026-01-01"),
+  fechaHasta: new Date("2026-12-31"),
+};
+
+test("usa TARJETA para online y CUENTA para transferencia como el backend", () => {
+  assert.equal(
+    getCouponPercentageForPaymentMethod(coupon, "online"),
+    12
+  );
+  assert.equal(
+    getCouponPercentageForPaymentMethod(coupon, "transfer"),
+    18
+  );
+});
+
+test("elige el cupón cuando su porcentaje es mayor", () => {
+  assert.deepEqual(
+    selectCheckoutDiscount({
+      automaticPercentage: 17,
+      couponPercentage: 20,
+    }),
+    { percentage: 20, source: "coupon" }
+  );
+});
+
+test("elige el descuento automático cuando es mayor", () => {
+  assert.deepEqual(
+    selectCheckoutDiscount({
+      automaticPercentage: 20,
+      couponPercentage: 17,
+    }),
+    { percentage: 20, source: "automatic" }
+  );
+});
+
+test("no suma cupón y descuento automático", () => {
+  assert.notEqual(
+    selectCheckoutDiscount({
+      automaticPercentage: 17,
+      couponPercentage: 20,
+    }).percentage,
+    37
+  );
+});
+
+test("en caso de empate conserva el descuento automático", () => {
+  assert.deepEqual(
+    selectCheckoutDiscount({
+      automaticPercentage: 17,
+      couponPercentage: 17,
+    }),
+    { percentage: 17, source: "automatic" }
+  );
+});
+
+test("aplica un cupón de categoría solamente a productos compatibles", () => {
+  assert.equal(
+    isCouponApplicableToProductCategory({
+      couponCategory: "filamento",
+      productCategory: "FILAMENTO 3D",
+    }),
+    true
+  );
+  assert.equal(
+    isCouponApplicableToProductCategory({
+      couponCategory: "filamento",
+      productCategory: "REPUESTOS",
+    }),
+    false
+  );
+  assert.equal(
+    isCouponApplicableToProductCategory({
+      couponCategory: null,
+      productCategory: "IMPRESORAS",
+    }),
+    true
+  );
+});
+
+test("deriva categorías con la misma regla del backend", () => {
+  assert.equal(deriveCouponCategory("FILAMENTOS"), "filamento");
+  assert.equal(deriveCouponCategory("FILAMENTO 3D"), "filamento");
+  assert.equal(deriveCouponCategory("IMPRESORAS"), "impresora");
+  assert.equal(deriveCouponCategory("REPUESTOS"), "repuesto");
+});

--- a/tests/checkoutPricing.test.cjs
+++ b/tests/checkoutPricing.test.cjs
@@ -14,3 +14,23 @@ test("calcula importes de checkout con el redondeo del backend", () => {
   assert.equal(pricing.subtotalBruto, 43528);
   assert.equal(pricing.subtotalNeto, 36999);
 });
+
+test("calcula el descuento sobre la línea completa antes de derivar el unitario", () => {
+  const pricing = calculateCheckoutLinePricing(23528, 5, 17);
+
+  assert.equal(pricing.subtotalBruto, 117640);
+  assert.equal(pricing.subtotalNeto, 97641);
+  assert.equal(pricing.precioUnitarioNeto, 19528);
+  assert.notEqual(
+    pricing.subtotalNeto,
+    pricing.precioUnitarioNeto * 5
+  );
+});
+
+test("normaliza el precio base al peso igual que PedidoService", () => {
+  const pricing = calculateCheckoutLinePricing(3498.9, 10, 0);
+
+  assert.equal(pricing.subtotalBruto, 34990);
+  assert.equal(pricing.subtotalNeto, 34990);
+  assert.equal(pricing.precioUnitarioNeto, 3499);
+});

--- a/tests/discounts.test.cjs
+++ b/tests/discounts.test.cjs
@@ -52,6 +52,10 @@ test("reconoce familias elegibles desde codigos de variantes", () => {
     true
   );
   assert.equal(
+    isEligibleForQuantityDiscount(filament("FM-PLA-1KG-AMAR"), 1),
+    true
+  );
+  assert.equal(
     calculateDiscountedPriceForProduct(
       filament("FM-PLA-1KG-AMAR"),
       28234,

--- a/tests/orderPricing.test.cjs
+++ b/tests/orderPricing.test.cjs
@@ -1,0 +1,328 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+require("sucrase/register/ts");
+
+const {
+  buildOrderAmounts,
+  calculateOrderLineAmounts,
+  calculateOrderTotal,
+  hasValidOrderLineAmounts,
+  isShippingProductName,
+} = require("../src/utils/orderPricing.ts");
+const {
+  calculateCheckoutLinePricing,
+} = require("../src/utils/checkoutPricing.ts");
+const {
+  calculateDiscountedLineTotalForProduct,
+  calculateDiscountedPriceForProduct,
+} = require("../src/utils/discounts.ts");
+const {
+  isCouponApplicableToProductCategory,
+  selectCheckoutDiscount,
+} = require("../src/utils/checkoutDiscount.ts");
+
+test("caso 1: checkout y payload preservan el subtotal de línea descontado", () => {
+  const checkoutLine = calculateCheckoutLinePricing(23528, 5, 17);
+  const order = buildOrderAmounts({
+    products: [
+      {
+        nombre: "PRODUCTO-1",
+        cantidad: 5,
+        precioBaseUnitario: 23528,
+        ajustePorcentaje: 17,
+      },
+    ],
+  });
+
+  assert.deepEqual(checkoutLine, {
+    subtotalBruto: 117640,
+    subtotalNeto: 97641,
+    precioUnitarioNeto: 19528,
+  });
+  assert.deepEqual(order, {
+    productos: [
+      {
+        nombre: "PRODUCTO-1",
+        cantidad: 5,
+        precio_unitario: 19528,
+        subtotal: 97641,
+        ajuste_porcentaje: 17,
+      },
+    ],
+    total: 97641,
+    costoEnvio: 0,
+    descuentoCupon: 0,
+    subtotalSinIva: 97641,
+    ivaImporte: 0,
+  });
+  assert.equal(order.productos[0].precio_unitario * 5, 97640);
+  assert.equal(hasValidOrderLineAmounts(order.productos), true);
+});
+
+test("caso 2: agrega el envío exactamente una vez", () => {
+  const order = buildOrderAmounts({
+    products: [
+      {
+        nombre: "PRODUCTO-2",
+        cantidad: 10,
+        precioBaseUnitario: 3499,
+        ajustePorcentaje: 0,
+      },
+    ],
+    shipping: {
+      nombre: "ENVIO",
+      costo: 5599,
+    },
+  });
+
+  assert.deepEqual(order, {
+    productos: [
+      {
+        nombre: "PRODUCTO-2",
+        cantidad: 10,
+        precio_unitario: 3499,
+        subtotal: 34990,
+        ajuste_porcentaje: 0,
+      },
+      {
+        nombre: "ENVIO",
+        cantidad: 1,
+        precio_unitario: 5599,
+        subtotal: 5599,
+        ajuste_porcentaje: 0,
+      },
+    ],
+    total: 40589,
+    costoEnvio: 5599,
+    descuentoCupon: 0,
+    subtotalSinIva: 40589,
+    ivaImporte: 0,
+  });
+  assert.equal(
+    calculateOrderTotal([order.productos[0].subtotal], order.costoEnvio),
+    40589
+  );
+  assert.equal(
+    isShippingProductName("ENV-07K-GM-DELIVERY"),
+    true
+  );
+});
+
+test("los descuentos automáticos usan la fórmula de línea completa", () => {
+  const product = { id: "3N3-PLA", category: "FILAMENTO 3D" };
+
+  assert.equal(
+    calculateDiscountedLineTotalForProduct(product, 23528, 5, 1, 5),
+    97641
+  );
+  assert.equal(
+    calculateDiscountedPriceForProduct(product, 23528, 5, 1, 5),
+    19528
+  );
+});
+
+test("el payload aplica el mayor porcentaje entre automático y cupón", () => {
+  const decision = selectCheckoutDiscount({
+    automaticPercentage: 17,
+    couponPercentage: 20,
+  });
+  const order = buildOrderAmounts({
+    products: [
+      {
+        nombre: "PRODUCTO-CUPON",
+        cantidad: 5,
+        precioBaseUnitario: 23528,
+        ajustePorcentaje: decision.percentage,
+        couponApplied: decision.source === "coupon",
+      },
+    ],
+    shipping: {
+      nombre: "ENV-07K-GM-DELIVERY",
+      costo: 5599,
+    },
+  });
+
+  assert.equal(decision.source, "coupon");
+  assert.deepEqual(order.productos[0], {
+    nombre: "PRODUCTO-CUPON",
+    cantidad: 5,
+    precio_unitario: 18822,
+    subtotal: 94112,
+    ajuste_porcentaje: 20,
+  });
+  assert.equal(order.productos[1].ajuste_porcentaje, 0);
+  assert.equal(order.productos[1].subtotal, 5599);
+  assert.equal(order.total, 99711);
+  assert.equal(order.descuentoCupon, 23528);
+});
+
+test("automático 20% supera al cupón 17% y descuento_cupon queda en cero", () => {
+  const decision = selectCheckoutDiscount({
+    automaticPercentage: 20,
+    couponPercentage: 17,
+  });
+  const order = buildOrderAmounts({
+    products: [
+      {
+        nombre: "PRODUCTO-AUTO-20",
+        cantidad: 5,
+        precioBaseUnitario: 23528,
+        ajustePorcentaje: decision.percentage,
+        couponApplied: decision.source === "coupon",
+      },
+    ],
+  });
+
+  assert.equal(decision.source, "automatic");
+  assert.equal(order.productos[0].subtotal, 94112);
+  assert.equal(order.descuentoCupon, 0);
+});
+
+test("automático 17% empata al cupón 17% y descuento_cupon queda en cero", () => {
+  const decision = selectCheckoutDiscount({
+    automaticPercentage: 17,
+    couponPercentage: 17,
+  });
+  const order = buildOrderAmounts({
+    products: [
+      {
+        nombre: "PRODUCTO-EMPATE",
+        cantidad: 5,
+        precioBaseUnitario: 23528,
+        ajustePorcentaje: decision.percentage,
+        couponApplied: decision.source === "coupon",
+      },
+    ],
+  });
+
+  assert.equal(decision.source, "automatic");
+  assert.equal(order.productos[0].subtotal, 97641);
+  assert.equal(order.descuentoCupon, 0);
+});
+
+test("un cupón por categoría sólo modifica las líneas aplicables", () => {
+  const categories = ["FILAMENTO 3D", "REPUESTOS"];
+  const decisions = categories.map((productCategory) =>
+    selectCheckoutDiscount({
+      automaticPercentage: 0,
+      couponPercentage: isCouponApplicableToProductCategory({
+        couponCategory: "filamento",
+        productCategory,
+      })
+        ? 20
+        : 0,
+    })
+  );
+  const order = buildOrderAmounts({
+    products: decisions.map((decision, index) => ({
+      nombre: `PRODUCTO-${index + 1}`,
+      cantidad: 1,
+      precioBaseUnitario: 100,
+      ajustePorcentaje: decision.percentage,
+      couponApplied: decision.source === "coupon",
+    })),
+  });
+
+  assert.equal(order.productos[0].subtotal, 80);
+  assert.equal(order.productos[1].subtotal, 100);
+  assert.equal(order.descuentoCupon, 20);
+  assert.equal(order.total, 180);
+});
+
+test("la validación acepta la diferencia válida entre subtotal y unitario por cantidad", () => {
+  assert.equal(
+    hasValidOrderLineAmounts([
+      {
+        cantidad: 5,
+        precio_unitario: 19528,
+        subtotal: 97641,
+        ajuste_porcentaje: 17,
+      },
+    ]),
+    true
+  );
+});
+
+test("factura A/B conserva dos decimales y redondea el total fiscal", () => {
+  const order = buildOrderAmounts({
+    products: [
+      {
+        nombre: "PRODUCTO-FACTURA",
+        cantidad: 2,
+        precioBaseUnitario: 23528,
+        ajustePorcentaje: 17,
+      },
+    ],
+    shipping: {
+      nombre: "ENVIO",
+      costo: 5599,
+    },
+    facturaTipo: "A",
+  });
+
+  assert.deepEqual(order.productos[0], {
+    nombre: "PRODUCTO-FACTURA",
+    cantidad: 2,
+    precio_unitario: 23628.88,
+    subtotal: 56937.76,
+    ajuste_porcentaje: 17,
+  });
+  assert.deepEqual(order.productos[1], {
+    nombre: "ENVIO",
+    cantidad: 1,
+    precio_unitario: 6774.79,
+    subtotal: 6774.79,
+    ajuste_porcentaje: 0,
+  });
+  assert.equal(order.costoEnvio, 5599);
+  assert.equal(order.subtotalSinIva, 44655);
+  assert.equal(order.ivaImporte, 9377.55);
+  assert.equal(order.total, 54032.55);
+  assert.equal(order.descuentoCupon, 0);
+  assert.equal(hasValidOrderLineAmounts(order.productos, "A"), true);
+});
+
+test("factura B calcula cupón completo sobre el neto y excluye envío", () => {
+  const order = buildOrderAmounts({
+    products: [
+      {
+        nombre: "PRODUCTO-FACTURA-CUPON",
+        cantidad: 2,
+        precioBaseUnitario: 23528,
+        ajustePorcentaje: 20,
+        couponApplied: true,
+      },
+    ],
+    shipping: {
+      nombre: "ENV-07K-GM-DELIVERY",
+      costo: 5599,
+    },
+    facturaTipo: "B",
+  });
+
+  assert.deepEqual(order.productos[0], {
+    nombre: "PRODUCTO-FACTURA-CUPON",
+    cantidad: 2,
+    precio_unitario: 22775.23,
+    subtotal: 56937.76,
+    ajuste_porcentaje: 20,
+  });
+  assert.equal(order.costoEnvio, 5599);
+  assert.equal(order.descuentoCupon, 9411);
+  assert.equal(order.subtotalSinIva, 43244);
+  assert.equal(order.ivaImporte, 9081.24);
+  assert.equal(order.total, 52325.24);
+});
+
+test("rechaza centavos en productos sin factura pero los acepta con factura", () => {
+  const lineWithCents = calculateOrderLineAmounts({
+    cantidad: 2,
+    precioBaseUnitario: 23528,
+    ajustePorcentaje: 17,
+    facturaTipo: "B",
+  });
+
+  assert.equal(hasValidOrderLineAmounts([lineWithCents], "none"), false);
+  assert.equal(hasValidOrderLineAmounts([lineWithCents], "B"), true);
+});


### PR DESCRIPTION
- Centralizar lógica de descuentos en selectCheckoutDiscount (automático vs cupón)
- Agregar getCouponPercentageForPaymentMethod y isCouponApplicableToProductCategory
- Crear buildOrderAmounts para construir importes consistentes antes de enviar al backend
- Normalizar precio base a entero (Math.round) en checkoutPricing
- En calculateInvoiceLine, normalizar precio base antes de aplicar IVA
- Validar importes con hasValidOrderLineAmounts antes de crear pedido
- Mostrar subtotal en PaymentCallback (usar subtotal enviado por backend)
- Identificar productos de envío en PaymentCallback con isShippingProductName
- Mostrar IVA en resumen de pago cuando corresponde
- Agregar categoría de cupón (categoriaAplicable) en tipo Coupon
- Validar categoría de producto contra cupón al aplicar
- Mejorar mensajes de error para cupones no aplicables
- Tests: validar normalización de precio base y descuento sobre línea completa