### PR TITLE
refactor(checkout): extraer lógica de dirección a orderAddress

### DIFF
--- a/src/components/checkout/Checkout.tsx
+++ b/src/components/checkout/Checkout.tsx
@@ -50,6 +50,7 @@ import {
   splitPersonalNameFromRazonSocial,
   stripArgentinaMobilePrefix,
 } from "../../utils/validation";
+import { buildOrderAddressPayload } from "../../utils/orderAddress";
 
 function useMediaQuery(query: string): boolean {
   const getMatches = () => {
@@ -526,23 +527,16 @@ export default function Checkout() {
       setShowErrorModal(true);
       return;
     }
-    // Dirección de envío
-    const calle = formData.street;
-    // const numero = formData.number;
-    const ciudad = formData.city;
-    const codigo_postal = formData.postalCode;
-    const region = "Mendoza";
-    const pais = "AR";
-
-    // Dirección de facturación (siempre se envía)
-    const billing_address = {
-      street: formData.billingStreet,
-      number: formData.addressWithoutNumber ? "" : formData.billingNumber,
-      city: formData.billingCity,
-      region: region,
-      country: pais,
-      postal_code: formData.billingPostalCode,
-    };
+    const orderAddress = buildOrderAddressPayload({
+      originalAddress: {
+        street: formData.street,
+        number: formData.number,
+        city: formData.city,
+        postalCode: formData.postalCode,
+        addressWithoutNumber: formData.addressWithoutNumber,
+      },
+      googleFormattedAddress: confirmedAddress,
+    });
 
     const cleanCuit = normalizeCuitCuil(formData.cuit); // Remover guiones y caracteres no numéricos
     const clienteNombre = formatCustomerNameForOrder({
@@ -576,17 +570,11 @@ export default function Checkout() {
       metodo_pago: paymentMethod,
       email: formData.email,
       telefono: formatArgentinaMobileForApi(formData.phone),
-      calle,
-      ciudad,
-      region,
-      pais,
-      codigo_postal,
+      ...orderAddress,
       tipo_envio: deliveryMethod,
       observaciones: formData.observaciones,
-      direccion: confirmedAddress || "",
       mobile: isMobile,
       productos,
-      billing_address,
       ...(requiresInvoice(facturaTipo) ? { factura_tipo: facturaTipo } : {}),
     };
     const API_URL = import.meta.env.VITE_API_URL; // Se usará cuando el pago esté activo

--- a/src/utils/orderAddress.ts
+++ b/src/utils/orderAddress.ts
@@ -1,0 +1,53 @@
+export type OriginalCheckoutAddress = {
+  street: string;
+  number: string;
+  city: string;
+  postalCode: string;
+  addressWithoutNumber: boolean;
+};
+
+export type OrderAddressPayload = {
+  calle: string;
+  ciudad: string;
+  region: string;
+  pais: string;
+  codigo_postal: string;
+  direccion: string;
+  billing_address: {
+    street: string;
+    number: string;
+    city: string;
+    region: string;
+    country: string;
+    postal_code: string;
+  };
+};
+
+export const buildOrderAddressPayload = ({
+  originalAddress,
+  googleFormattedAddress,
+  region = "Mendoza",
+  country = "AR",
+}: {
+  originalAddress: OriginalCheckoutAddress;
+  googleFormattedAddress: string | null;
+  region?: string;
+  country?: string;
+}): OrderAddressPayload => ({
+  calle: originalAddress.street,
+  ciudad: originalAddress.city,
+  region,
+  pais: country,
+  codigo_postal: originalAddress.postalCode,
+  direccion: googleFormattedAddress || "",
+  billing_address: {
+    street: originalAddress.street,
+    number: originalAddress.addressWithoutNumber
+      ? ""
+      : originalAddress.number,
+    city: originalAddress.city,
+    region,
+    country,
+    postal_code: originalAddress.postalCode,
+  },
+});

--- a/tests/orderAddress.test.cjs
+++ b/tests/orderAddress.test.cjs
@@ -1,0 +1,90 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+require("sucrase/register/ts");
+
+const {
+  buildOrderAddressPayload,
+} = require("../src/utils/orderAddress.ts");
+
+const originalAddress = Object.freeze({
+  street: "B° Unidad Latinoamérica MC",
+  number: "C3",
+  city: "Las Heras",
+  postalCode: "5539",
+  addressWithoutNumber: false,
+});
+
+test("envía los campos originales y la dirección normalizada de Google por separado", () => {
+  const payload = buildOrderAddressPayload({
+    originalAddress,
+    googleFormattedAddress:
+      "Dorrego 229, M5539 Las Heras, Mendoza, Argentina",
+  });
+
+  assert.deepEqual(payload, {
+    calle: "B° Unidad Latinoamérica MC",
+    ciudad: "Las Heras",
+    region: "Mendoza",
+    pais: "AR",
+    codigo_postal: "5539",
+    direccion: "Dorrego 229, M5539 Las Heras, Mendoza, Argentina",
+    billing_address: {
+      street: "B° Unidad Latinoamérica MC",
+      number: "C3",
+      city: "Las Heras",
+      region: "Mendoza",
+      country: "AR",
+      postal_code: "5539",
+    },
+  });
+});
+
+test("mover el pin cambia solamente direccion y no modifica los datos originales", () => {
+  const firstSelection = buildOrderAddressPayload({
+    originalAddress,
+    googleFormattedAddress:
+      "Dorrego 229, M5539 Las Heras, Mendoza, Argentina",
+  });
+  const secondSelection = buildOrderAddressPayload({
+    originalAddress,
+    googleFormattedAddress:
+      "Dorrego 245, M5539 Las Heras, Mendoza, Argentina",
+  });
+
+  assert.equal(
+    secondSelection.direccion,
+    "Dorrego 245, M5539 Las Heras, Mendoza, Argentina"
+  );
+  assert.deepEqual(
+    { ...secondSelection, direccion: firstSelection.direccion },
+    firstSelection
+  );
+  assert.deepEqual(originalAddress, {
+    street: "B° Unidad Latinoamérica MC",
+    number: "C3",
+    city: "Las Heras",
+    postalCode: "5539",
+    addressWithoutNumber: false,
+  });
+});
+
+test("una dirección sin número conserva los demás originales y vacía solo billing number", () => {
+  const payload = buildOrderAddressPayload({
+    originalAddress: {
+      ...originalAddress,
+      number: "",
+      addressWithoutNumber: true,
+    },
+    googleFormattedAddress:
+      "Barrio Unidad Latinoamérica, M5539 Las Heras, Mendoza, Argentina",
+  });
+
+  assert.equal(payload.calle, originalAddress.street);
+  assert.equal(payload.billing_address.street, originalAddress.street);
+  assert.equal(payload.billing_address.number, "");
+  assert.equal(
+    payload.direccion,
+    "Barrio Unidad Latinoamérica, M5539 Las Heras, Mendoza, Argentina"
+  );
+});


### PR DESCRIPTION
- Crear buildOrderAddressPayload en utils/orderAddress.ts
- Construir payload de dirección unificado (calle, ciudad, region, pais, codigo_postal)
- Incluir direccion y billing_address según corresponda
- Simplificar Checkout.tsx eliminando lógica de dirección inline
- Mejorar mantenibilidad y tests del payload de dirección